### PR TITLE
Prevent redundant code checks

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 name: Continuous Integration


### PR DESCRIPTION
With branch protection preventing pushes to master we can rely on only running code checks on pull request and requiring successful checks for merge.