### PR TITLE
Fix unlock_task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
-- Added `GameInterfaceProvider` trait for types that are caple of providing a game interface.
+- Added `InterfaceProvider` trait for types that are caple of providing a game interface.
 - Added `MockInterface` for writing testing logic without using a real backend.
 - Added `GameVar` and `GameVarMut` traits to represent accessible regions of game memory in a strongly-typed manner.
 - Added `InterfaceError::HookingFailed` for when a hooking attempt fails. `InterfaceError::Unhooked`
   represents when a previously hooked interface becomes unhooked.
+
+### Fixed
+
+- `GameInterface::unlock_task` will now only set a task's counter to `1` if it was previously `0`. This will preserve a
+  value of `3` which can also correspond to an "silver" task (e.g. Infestation at the Krusty Krab)
 
 ### Removals
 

--- a/src/game_interface/mod.rs
+++ b/src/game_interface/mod.rs
@@ -92,7 +92,8 @@ pub struct Task<F: InterfaceBackend> {
     /// - `0` => Task is "locked", will be a question mark in the menu.
     /// - `1` => Task is "incomplete", will be a silver spatula in the menu.
     /// - `2` => Task is "complete", will be a golden spatula in the menu.
-    /// - `3` => Task is also silver in the menu, may have some semantics not currently understood.
+    /// - `3` => Task is also silver in the menu, this appears to only be used by [`Spatula::InfestationAtTheKrustyKrab`],
+    ///          which uses this value for after clearing the robots, but before you've collected the spatula.
     /// - `_` => No icon will appear for this task in the menu, just an empty bubble. You can not warp to it and
     ///          attempting to will put the menu into an invalid state until a different unlocked task is selected.
     pub menu_count: F::Mut<i16>,

--- a/src/game_interface/mod.rs
+++ b/src/game_interface/mod.rs
@@ -146,7 +146,7 @@ impl<F: InterfaceBackend> GameInterface<F> {
     pub fn unlock_task(&mut self, spatula: Spatula) -> InterfaceResult<()> {
         let task = &mut self.tasks[spatula];
         let curr = task.menu_count.get()?;
-        if curr != 2 {
+        if curr == 0 {
             task.menu_count.set(1)?;
         }
         Ok(())


### PR DESCRIPTION
We should no longer erroneously set a `3` to `1`. This fixes the Krusty Krab problem with Clash and may prevent some other currently unknown errors. We may need to revisit this in the future where we add logic to decide whether to change a spatula to `1` or to `3`